### PR TITLE
Ensure EventBridge notifier in Admin UI uses value that is consistent with the notifier declaration

### DIFF
--- a/MageOS/AsyncEventsAWS/Plugin/MageOS/AsyncEventsAdminUi/UiSourceNotifiers.php
+++ b/MageOS/AsyncEventsAWS/Plugin/MageOS/AsyncEventsAdminUi/UiSourceNotifiers.php
@@ -8,7 +8,7 @@ class UiSourceNotifiers
     public function afterToOptionArray(Subject $subject, $result)
     {
         $result[] = [
-            'value' => 'event_bridge',
+            'value' => 'eventbridge',
             'label' => 'AWS Event Bridge',
         ];
         return $result;


### PR DESCRIPTION
Fixes #9 

The EventBridge notifier is declared with a value of `eventbridge`, but the UI source uses `event_bridge`. This PR changes the UI source value to `eventbridge` to ensure consistency.